### PR TITLE
Fix ConversationsCreateBody Participants Attribute

### DIFF
--- a/lib/sunshine-conversations-client/models/conversation_create_body.rb
+++ b/lib/sunshine-conversations-client/models/conversation_create_body.rb
@@ -81,6 +81,7 @@ module SunshineConversationsClient
       end
 
       if attributes.key?(:'participants')
+        self.participants = attributes[:'participants']
       end
 
       if attributes.key?(:'display_name')


### PR DESCRIPTION
This class did not correctly assign the participants attribute during the construction of the class.

This change addresses the need by:
* Assigning participants during construction