### PR TITLE
Fix Timeout ApiError

### DIFF
--- a/lib/sunshine-conversations-client/api_client.rb
+++ b/lib/sunshine-conversations-client/api_client.rb
@@ -53,7 +53,8 @@ module SunshineConversationsClient
 
       unless response.success?
         if response.timed_out?
-          fail ApiError.new('Connection timed out')
+          fail ApiError.new(:code => 408,
+                            :message => 'Connection timed out')
         elsif response.code == 0
           # Errors from libcurl will be made visible here
           fail ApiError.new(:code => 0,


### PR DESCRIPTION
ApiError.new('Connection timed out') doesn't pass the 'Connection timed out' string argument to the message attribute, instead returning the default message error. I suggest explicitly passing the message argument and adding 408 as the error code.

![image](https://github.com/zendesk/sunshine-conversations-ruby/assets/22482633/787c957b-7c3c-45d2-a566-db3f27a487e7)

![image](https://github.com/zendesk/sunshine-conversations-ruby/assets/22482633/8b695417-da36-43b8-937e-bb073788bccc)

